### PR TITLE
feat: add lichess support

### DIFF
--- a/check_for_updates.js
+++ b/check_for_updates.js
@@ -1,8 +1,8 @@
-import {get_chess_stats, get_most_recent_game, get_game_result} from "./chess_utils.js";
+import {get_chess_stats, get_most_recent_game, get_game_result, get_lichess_stats, get_lichess_most_recent_game} from "./chess_utils.js";
 import {getRandomWinMsg, getRandomLoseMsg, getRandomDrawMsg} from "./messages.js";
 import {send_message_to_channel} from "./app.js";
 import * as console from "node:console";
-import { clubMembers } from "./club_members.js";
+import { clubMembers, lichessClubMembers } from "./club_members.js";
 
 
 
@@ -10,6 +10,7 @@ export async function check_for_updates(channel_id){
     console.log('Sending updates...');
 
     let userRatingsMap = await get_most_recent_stats();
+    let lichessRatingsMap = await get_most_recent_lichess_stats();
     // Function to check for updates
     const checkAndSendUpdates = async () => {
 
@@ -71,6 +72,61 @@ export async function check_for_updates(channel_id){
                 console.error(`Error processing ${username}:`, error);
             }
         }
+
+        for (const username of lichessClubMembers) {
+            try {
+                let most_recent_game = "";
+                const profile = await get_lichess_stats(username);
+                const mostRecentGame = await get_lichess_most_recent_game(username);
+
+                if (mostRecentGame && mostRecentGame.url) {
+                    most_recent_game = mostRecentGame.url;
+                }
+
+                const newRatings = {
+                    chess_bullet: profile?.perfs?.bullet?.rating || 0,
+                    chess_blitz: profile?.perfs?.blitz?.rating || 0,
+                    chess_rapid: profile?.perfs?.rapid?.rating || 0,
+                    recent_game: most_recent_game,
+                };
+
+                const lastRating = lichessRatingsMap.get(username);
+
+                if (!lastRating || newRatings.recent_game !== lastRating.recent_game) {
+
+                    console.log(`New Lichess game detected for ${username}`);
+                    const time_control = mostRecentGame?.time_class;
+                    let ratingChange = 0;
+                    let new_rating = 0;
+
+                    if (time_control === "rapid") {
+                        ratingChange = newRatings.chess_rapid - (lastRating?.chess_rapid || 0);
+                        new_rating = newRatings.chess_rapid;
+                    } else if (time_control === "blitz") {
+                        ratingChange = newRatings.chess_blitz - (lastRating?.chess_blitz || 0);
+                        new_rating = newRatings.chess_blitz;
+                    } else if (time_control === "bullet") {
+                        ratingChange = newRatings.chess_bullet - (lastRating?.chess_bullet || 0);
+                        new_rating = newRatings.chess_bullet;
+                    }
+
+                    const game_result = get_game_result(username, mostRecentGame);
+
+                    if (game_result.result === "loss") {
+                        await send_message_to_channel(channel_id, getRandomLoseMsg(time_control, username, ratingChange, new_rating, mostRecentGame, game_result.loss_type));
+                    } else if (game_result.result === "win") {
+                        await send_message_to_channel(channel_id, getRandomWinMsg(time_control, username, ratingChange, new_rating, mostRecentGame, game_result.loss_type));
+                    } else if (game_result.result === "draw") {
+                        await send_message_to_channel(channel_id, getRandomDrawMsg(time_control, username, ratingChange, new_rating, mostRecentGame));
+                    }
+
+                    lichessRatingsMap.set(username, newRatings);
+                }
+
+            } catch (error) {
+                console.error(`Error processing lichess user ${username}:`, error);
+            }
+        }
     };
 
     await checkAndSendUpdates(); // Initial check
@@ -110,6 +166,41 @@ async function get_most_recent_stats() {
             chess_blitz: userStats?.chess_blitz?.last?.rating || 0,
             chess_rapid: userStats?.chess_rapid?.last?.rating || 0,
             recent_game: most_recent_game
+        };
+
+        user_rating_map.set(user, userRatings);
+    }
+    return user_rating_map;
+}
+
+async function get_most_recent_lichess_stats() {
+    let user_rating_map = new Map();
+
+    for (const user of lichessClubMembers) {
+        let most_recent_game = ``;
+
+        try {
+            const mostRecentGame = await get_lichess_most_recent_game(user);
+            if (mostRecentGame && mostRecentGame.url) {
+                most_recent_game = mostRecentGame.url;
+            }
+        } catch (error) {
+            console.error(`Error fetching most recent Lichess game for ${user}:`, error);
+        }
+
+        let userStats;
+        try {
+            userStats = await get_lichess_stats(user);
+        } catch (error) {
+            console.error(`Error fetching Lichess stats for ${user}:`, error);
+            continue;
+        }
+
+        const userRatings = {
+            chess_bullet: userStats?.perfs?.bullet?.rating || 0,
+            chess_blitz: userStats?.perfs?.blitz?.rating || 0,
+            chess_rapid: userStats?.perfs?.rapid?.rating || 0,
+            recent_game: most_recent_game,
         };
 
         user_rating_map.set(user, userRatings);

--- a/chess_utils.js
+++ b/chess_utils.js
@@ -25,13 +25,15 @@ export async function get_chess_recent_games(userName) {
     }
 }
 
-    export async function get_most_recent_game(username) {
+export async function get_most_recent_game(username) {
     const mostRecentGames = await get_chess_recent_games(username);
 
     if (mostRecentGames.games && mostRecentGames.games.length > 0) {
-        return mostRecentGames.games[mostRecentGames.games.length - 1]; // Get last game in the list
+        const game = mostRecentGames.games[mostRecentGames.games.length - 1]; // Get last game in the list
+        game.site = 'chess.com';
+        return game;
     } else {
-        return ``;
+        return null;
     }
 }
 
@@ -46,6 +48,76 @@ export async function get_chess_profile(username) {
     const url = `https://api.chess.com/pub/player/${username.toLowerCase()}`;
 
     return await getResponse(url);
+}
+
+function mapLichessStatus(status) {
+    switch (status) {
+        case 'timeout':
+        case 'outoftime':
+            return 'timeout';
+        case 'resign':
+            return 'resigned';
+        case 'mate':
+            return 'checkmated';
+        case 'aborted':
+            return 'abandoned';
+        default:
+            return status;
+    }
+}
+
+export async function get_lichess_most_recent_game(username) {
+    const url = `https://lichess.org/api/games/user/${username}?max=1&opening=true&pgnInJson=true&sort=dateDesc`;
+    try {
+        const response = await fetch(url, { headers: { 'Accept': 'application/x-ndjson' } });
+        const text = await response.text();
+        const line = text.trim().split('\n')[0];
+        if (!line) {
+            return null;
+        }
+        const data = JSON.parse(line);
+        const { players, id, pgn, speed, winner, status } = data;
+        let whiteResult, blackResult;
+        if (winner === 'white') {
+            whiteResult = 'win';
+            blackResult = mapLichessStatus(status);
+        } else if (winner === 'black') {
+            whiteResult = mapLichessStatus(status);
+            blackResult = 'win';
+        } else {
+            whiteResult = 'draw';
+            blackResult = 'draw';
+        }
+
+        return {
+            site: 'lichess',
+            url: `https://lichess.org/${id}`,
+            pgn: pgn,
+            time_class: speed,
+            white: {
+                username: players?.white?.user?.name || 'anonymous',
+                result: whiteResult,
+            },
+            black: {
+                username: players?.black?.user?.name || 'anonymous',
+                result: blackResult,
+            },
+        };
+    } catch (error) {
+        console.error(`Error fetching recent Lichess game for ${username}:`, error);
+        return null;
+    }
+}
+
+export async function get_lichess_stats(userName) {
+    const url = `https://lichess.org/api/user/${userName}`;
+    try {
+        const response = await fetch(url);
+        return await response.json();
+    } catch (error) {
+        console.error(`Error fetching Lichess stats for ${userName}:`, error);
+        return null;
+    }
 }
 
 async function getResponse(link) {

--- a/club_members.js
+++ b/club_members.js
@@ -15,4 +15,7 @@ export const clubMembers = [
     "seanb354",
 ];
 
-export const lichessClubMembers = []
+// Array to hold lichess.org usernames
+export const lichessClubMembers = [
+    // Add Lichess usernames here
+];

--- a/messages.js
+++ b/messages.js
@@ -99,39 +99,48 @@ function game_info(game, username, newRating) {
 
 function format_message(message, game, username, color = 0x630031, newRating) {
     console.log(`Format Message: ${message}`);
-    const profile_url = `https://www.chess.com/member/${username.toLowerCase()}`;
+    const profile_url = game.site === 'lichess'
+        ? `https://lichess.org/@/${username}`
+        : `https://www.chess.com/member/${username.toLowerCase()}`;
+
+    const buttons = [
+        {
+            type: 2,
+            label: "Game Link",
+            style: 5,
+            url: game.url,
+        },
+        {
+            type: 2,
+            label: `View ${username}'s Profile`,
+            style: 5,
+            url: profile_url,
+        },
+    ];
+
+    const openingUrl = getEcoUrl(game);
+    if (openingUrl) {
+        buttons.push({
+            type: 2,
+            label: `See Opening`,
+            style: 5,
+            url: openingUrl,
+        });
+    }
+
     return JSON.stringify({
         embeds: [
             {
                 title: message,
                 description: game_info(game, username, newRating),
                 color: color,
-            }
+            },
         ],
         components: [
             {
-                type: 1, // An action for the buttons
-                components: [
-                    {
-                        type: 2,       // A button
-                        label: "Game Link",
-                        style: 5,      // 5 is the 'Link' style
-                        url: game.url   // The actual link
-                    },
-                    {
-                        type: 2,
-                        label: `View ${username}'s Profile`,
-                        style: 5,
-                        url: profile_url
-                    },
-                    {
-                        type: 2,
-                        label: `See Opening`,
-                        style: 5,
-                        url: getEcoUrl(game)
-                    }
-                ]
-            }
-        ]
+                type: 1,
+                components: buttons,
+            },
+        ],
     });
 }


### PR DESCRIPTION
## Summary
- track lichess players alongside chess.com members
- include lichess profile URLs and game checks in message and update logic

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check chess_utils.js check_for_updates.js messages.js club_members.js`


------
https://chatgpt.com/codex/tasks/task_e_689e14280e04832a8320e15c11b14929