### PR TITLE
feat: add leaderboard command

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,13 +3,40 @@ import 'dotenv/config';
 import express from 'express';
 import { InteractionType, InteractionResponseType, MessageComponentTypes, verifyKeyMiddleware,} from 'discord-interactions';
 import {getRandomEmoji} from './utils.js';
-import {get_chess_profile, get_most_recent_game} from "./chess_utils.js";
+import {get_chess_profile, get_most_recent_game, get_chess_stats, get_games_in_last_days, get_game_result} from "./chess_utils.js";
+import {clubMembers} from './club_members.js';
 import {check_for_updates} from './check_for_updates.js';
 
 // Create an express app
 const app = express();
 // Get port, or default to 3000
 const PORT = process.env.PORT;
+
+async function buildLeaderboard(metric, period) {
+  const daysMap = { day: 1, week: 7, month: 30 };
+  const days = daysMap[period] || 7;
+
+  const entries = await Promise.all(clubMembers.map(async (username) => {
+    if (metric === 'rating') {
+      const stats = await get_chess_stats(username);
+      const rating = stats?.chess_rapid?.last?.rating || 0;
+      return { username, value: rating };
+    } else {
+      const games = await get_games_in_last_days(username, days);
+      if (metric === 'games_won') {
+        const wins = games.filter(g => get_game_result(username, g).result === 'win').length;
+        return { username, value: wins };
+      }
+      return { username, value: games.length };
+    }
+  }));
+
+  entries.sort((a, b) => b.value - a.value);
+  const title = metric.replace('_', ' ');
+  const header = `Leaderboard - ${title} (${period})`;
+  const lines = entries.map((e, idx) => `${idx + 1}. ${e.username} - ${e.value}`);
+  return `**${header}**\n${lines.join('\n')}`;
+}
 
 /**
  * Interactions endpoint URL where Discord will send HTTP requests
@@ -94,6 +121,18 @@ app.post('/interactions', verifyKeyMiddleware(process.env.PUBLIC_KEY), async fun
         data: {
           // Fetches a random emoji to send from a helper function
           content: `Set channel succeeded`,
+        },
+      });
+    }
+
+    if (name === 'leaderboard') {
+      const metricOption = data.options?.find(o => o.name === 'metric')?.value || 'rating';
+      const periodOption = data.options?.find(o => o.name === 'period')?.value || 'week';
+      const message = await buildLeaderboard(metricOption, periodOption);
+      return res.send({
+        type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+        data: {
+          content: message,
         },
       });
     }

--- a/chess_utils.js
+++ b/chess_utils.js
@@ -36,6 +36,29 @@ export async function get_chess_recent_games(userName) {
 }
 
 
+export async function get_games_in_last_days(username, days) {
+    const now = new Date();
+    const months = [{ year: now.getFullYear(), month: now.getMonth() + 1 }];
+    const previous = new Date(now);
+    previous.setMonth(previous.getMonth() - 1);
+    if (days > now.getDate()) {
+        months.push({ year: previous.getFullYear(), month: previous.getMonth() + 1 });
+    }
+
+    let games = [];
+    for (const { year, month } of months) {
+        const formattedMonth = month.toString().padStart(2, '0');
+        const url = `https://api.chess.com/pub/player/${username.toLowerCase()}/games/${year}/${formattedMonth}`;
+        const response = await getResponse(url);
+        if (response && Array.isArray(response.games)) {
+            games = games.concat(response.games);
+        }
+    }
+
+    const cutoff = now.getTime() - days * 24 * 60 * 60 * 1000;
+    return games.filter(g => g.end_time * 1000 >= cutoff);
+}
+
 export async function get_chess_stats(userName) {
     const url = `https://api.chess.com/pub/player/${userName.toLowerCase()}/stats`;
 

--- a/commands.js
+++ b/commands.js
@@ -26,6 +26,38 @@ const SET_CHESS_ACTIVITY_CHANNEL = {
   contexts: [0, 1, 2],
 };
 
-const ALL_COMMANDS = [TEST_COMMAND, LINK_ACCOUNT, SET_CHESS_ACTIVITY_CHANNEL];
+const LEADERBOARD = {
+  name: 'leaderboard',
+  description: 'Display club leaderboard',
+  type: 1,
+  integration_types: [0, 1],
+  contexts: [0, 1, 2],
+  options: [
+    {
+      name: 'metric',
+      description: 'Statistic to sort by',
+      type: 3,
+      required: true,
+      choices: [
+        { name: 'rating', value: 'rating' },
+        { name: 'games_played', value: 'games_played' },
+        { name: 'games_won', value: 'games_won' },
+      ],
+    },
+    {
+      name: 'period',
+      description: 'Time period',
+      type: 3,
+      required: false,
+      choices: [
+        { name: 'day', value: 'day' },
+        { name: 'week', value: 'week' },
+        { name: 'month', value: 'month' },
+      ],
+    },
+  ],
+};
+
+const ALL_COMMANDS = [TEST_COMMAND, LINK_ACCOUNT, SET_CHESS_ACTIVITY_CHANNEL, LEADERBOARD];
 
 InstallGlobalCommands(process.env.APP_ID, ALL_COMMANDS)


### PR DESCRIPTION
## Summary
- add `/leaderboard` slash command with metric and period options
- fetch recent games and ratings to build leaderboard output
- support counting games played or won within day, week or month

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_689e1e77aa30832ab2f404933adf33d4